### PR TITLE
Fix throttle reset after successful login

### DIFF
--- a/app/Filters/ThrottleFilter.php
+++ b/app/Filters/ThrottleFilter.php
@@ -87,10 +87,16 @@ class ThrottleFilter implements FilterInterface
         // If login was successful, clear the throttle
         if ($response->getStatusCode() === 200 || $response->getStatusCode() === 302) {
             $session = session();
-            if ($session->get('logged_in') || $session->get('user_id')) {
+            if ($session->get('isLoggedIn') || $session->get('logged_in') || $session->get('user_id')) {
                 $key = $this->resolveRequestSignature($request);
                 $this->cache->delete($key);
                 $this->cache->delete('blocked_' . $key); // Fixed: use underscore
+
+                $baseKey = $this->resolveBaseRequestSignature($request);
+                if ($baseKey !== $key) {
+                    $this->cache->delete($baseKey);
+                    $this->cache->delete('blocked_' . $baseKey);
+                }
             }
         }
     }
@@ -119,6 +125,17 @@ class ThrottleFilter implements FilterInterface
         $safeKey = 'throttle_' . md5($ip . '_' . $route . $identifier);
 
         return $safeKey;
+    }
+
+    /**
+     * Generate base signature without user identifier
+     */
+    protected function resolveBaseRequestSignature(RequestInterface $request): string
+    {
+        $ip = $request->getIPAddress();
+        $route = $request->getUri()->getPath();
+
+        return 'throttle_' . md5($ip . '_' . $route);
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure throttle filter recognizes the session flag set by the authentication controller
- clear both identifier-specific and base throttle cache keys after a successful login

## Testing
- composer test *(fails: phpunit executable is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da46df6d608329a0860d5b680b4af7